### PR TITLE
Workaround for build errors on closed hardware

### DIFF
--- a/Assets/FractalSDK/Scripts/Core/FractalLoginHandler.cs
+++ b/Assets/FractalSDK/Scripts/Core/FractalLoginHandler.cs
@@ -38,9 +38,9 @@ namespace FractalSDK.Core
 
         #endregion
 
-
         #region Externals
 
+#if !UNITY_SWITCH && !UNITY_PS4 && !UNITY_PS4 && !UNITY_XBOXONE
         //[External JS Call]
         [DllImport("__Internal")]
         private static extern void SetupFractalEvents();
@@ -52,6 +52,24 @@ namespace FractalSDK.Core
         //[External JS Call]
         [DllImport("__Internal")]
         private static extern void CloseFractalPopup();
+
+#else
+        private static void SetupFractalEvents()
+        {
+            throw new NotImplementedException();
+        }
+
+        private static void OpenFractalPopup(string url)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static void CloseFractalPopup()
+        {
+            throw new NotImplementedException();
+        }
+
+#endif
 
         #endregion
 

--- a/Assets/FractalSDK/Scripts/Core/FractalOnrampHandler.cs
+++ b/Assets/FractalSDK/Scripts/Core/FractalOnrampHandler.cs
@@ -21,12 +21,21 @@ namespace FractalSDK.Core
 
         #region Externals
 
+#if !UNITY_SWITCH && !UNITY_PS4 && !UNITY_PS4 && !UNITY_XBOXONE
+
         //[External JS Call]
         [DllImport("__Internal")]
         private static extern void OpenFractalPopup(string url);
 
-        #endregion
+#else
+        private static void OpenFractalPopup(string url)
+        {
+            throw new NotImplementedException();
+        }
 
+
+#endif
+        #endregion
 
         void Start()
         {


### PR DESCRIPTION
This will allow compilation on closed hardware (PS5, XBox, Switch) until externals are built for those platforms.

For now will throw NotImplemented Exceptions on those platforms.

Needs to be tested if there are any conflicts on working platforms.

Workaround for issue #7 